### PR TITLE
Remove use of define_method

### DIFF
--- a/lib/active_record/base_class_fix.rb
+++ b/lib/active_record/base_class_fix.rb
@@ -5,12 +5,21 @@ module ActiveRecord
 
   # We have to override Inheritance.ClassMethods.base_class, because we don't directly subclass from ActiveRecord::Base.
   module BaseClassFix
+    def base_class
+      self
+    end
+
     def self.extended(mod)
-      define_method :base_class, -> { mod }
-      mod.class.__send__(:define_method, :abstract_class?, -> { false })
+      mod.class.class_eval {
+        def abstract_class?
+          false
+        end
+      }
+
       def connection_specification_name
         "primary" # FIXME: This should be the default, but should be overridable, like normal ActiveRecord.
       end
+
       def connection
         ActiveRecord::Base.connection
       end

--- a/lib/active_record/entity.rb
+++ b/lib/active_record/entity.rb
@@ -11,10 +11,14 @@ module ActiveModel
   end
 
   def self.composite_module(modules)
-    Module.new.tap { |composite_module|
-      composite_module.define_singleton_method(:included) do |entity_module|
-        modules.each do |mod|
-          entity_module.__send__(:include, mod)
+    Module.new {
+      @modules = modules
+
+      def self.included(entity_module)
+        @modules.each do |mod|
+          entity_module.class_eval {
+            include mod
+          }
         end
       end
     }


### PR DESCRIPTION
Hey @booch! Just saw your RailsConf talk and loved it, nice work!

I noticed the project uses `define_method` in a few places. Obviously that's a perfectly valid approach, but I think what it's trying to do can be accomplished without creating a closure. By and large, methods defined in the "normal" way are faster to invoke than ones created with `define_method`. What do you think?